### PR TITLE
feat(stock-filter): Add option to hide out-of-stock filter item

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -23,6 +23,7 @@ class Config extends AbstractHelper
     /**
      * Configuration paths
      */
+    public const XML_PATH_DISPLAY_OUT_OF_STOCK = 'amadeco_elasticsuite_stock/general/display_out_of_stock_filter';
     public const XML_PATH_CONSIDER_ONLY_QTY = 'amadeco_elasticsuite_stock/general/consider_only_qty';
 
     /**
@@ -40,6 +41,22 @@ class Config extends AbstractHelper
     ) {
         parent::__construct($context);
         $this->inventoryConfig = $inventoryConfig;
+    }
+
+    /**
+     * Check if we need show out of stock filter
+     *
+     * @param int|null $storeId Store ID
+     *
+     * @return bool
+     */
+    public function shouldDisplayOutOfStockFilter(?int $storeId = null): bool
+    {
+        return $this->scopeConfig->isSetFlag(
+            self::XML_PATH_DISPLAY_OUT_OF_STOCK,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
     }
 
     /**

--- a/Model/Layer/Filter/Stock.php
+++ b/Model/Layer/Filter/Stock.php
@@ -152,6 +152,10 @@ class Stock extends \Smile\ElasticsuiteCatalog\Model\Layer\Filter\Boolean
             }
         }
 
+        if ($this->config->shouldDisplayOutOfStockFilter()) {
+            unset($items[MagentoModelStock::STOCK_OUT_OF_STOCK]);
+        }
+
         return $items;
     }
 

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -17,6 +17,10 @@
             <resource>Smile_ElasticsuiteCore::configuration</resource>
             <group id="general" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>General Configuration</label>
+                <field id="display_out_of_stock_filter" translate="label comment" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Display Out Of Stock Filter</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
                 <field id="consider_only_qty" translate="label comment" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Consider Only Product Quantity</label>
                     <comment>If set to Yes, stock filter will consider only product quantity. Products with qty ≤ 0 will be considered out of stock. Please note, if you change this value, you will need to reindex Catalog Search index</comment>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -13,6 +13,7 @@
     <default>
         <amadeco_elasticsuite_stock>
             <general>
+                <display_out_of_stock_filter>0</display_out_of_stock_filter>
                 <consider_only_qty>1</consider_only_qty>
             </general>
         </amadeco_elasticsuite_stock>


### PR DESCRIPTION
This commit adds the ability to hide the "Out of Stock" filter option in the layered navigation, providing a cleaner interface for stores that prefer to show only in-stock products by default.

## New Features
- Added configuration option `Display Out Of Stock Filter` in ElasticSuite > Stock Filter section
- Default behavior hides the "Out of Stock" filter option (backward compatible)
- Renamed configuration option from `consider_quantity` to `consider_only_qty` for better clarity

## Technical Changes
- Added new configuration constant `XML_PATH_DISPLAY_OUT_OF_STOCK` in Config helper
- Implemented `shouldDisplayOutOfStockFilter()` method to check this configuration
- Modified `_getItemsData()` in Stock filter class to conditionally remove the out-of-stock option
- Updated system.xml with new configuration field and proper labels/comments
- Added default configuration values in config.xml
- Renamed method to match new configuration name: `shouldConsiderOnlyQuantity()`

## Benefits
- More customizable user interface for different business needs
- Cleaner navigation for stores focusing only on available products
- Maintains the ability to filter by both in-stock and out-of-stock when needed

No database schema changes or reindexing required when changing the display configuration.