### PR TITLE
fix: respect native magento options and data

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -24,7 +24,6 @@ class Config extends AbstractHelper
      * Configuration paths
      */
     public const XML_PATH_DISPLAY_OUT_OF_STOCK = 'amadeco_elasticsuite_stock/general/display_out_of_stock_filter';
-    public const XML_PATH_CONSIDER_ONLY_QTY = 'amadeco_elasticsuite_stock/general/consider_only_qty';
 
     /**
      * @var InventoryConfig
@@ -54,22 +53,6 @@ class Config extends AbstractHelper
     {
         return $this->scopeConfig->isSetFlag(
             self::XML_PATH_DISPLAY_OUT_OF_STOCK,
-            ScopeInterface::SCOPE_STORE,
-            $storeId
-        );
-    }
-
-    /**
-     * Check if we should consider product quantity for stock status
-     *
-     * @param int|null $storeId Store ID
-     *
-     * @return bool
-     */
-    public function shouldConsiderOnlyQuantity(?int $storeId = null): bool
-    {
-        return $this->scopeConfig->isSetFlag(
-            self::XML_PATH_CONSIDER_ONLY_QTY,
             ScopeInterface::SCOPE_STORE,
             $storeId
         );

--- a/Model/Product/Indexer/Fulltext/Datasource/StockStatusData.php
+++ b/Model/Product/Indexer/Fulltext/Datasource/StockStatusData.php
@@ -58,7 +58,6 @@ class StockStatusData implements DatasourceInterface
      */
     public function addData($storeId, array $indexData)
     {
-        $shouldConsiderOnlyQty = $this->config->shouldConsiderOnlyQuantity((int)$storeId);
         $isBackordersAllowed = $this->config->isBackordersAllowed((int)$storeId);
 
         $attributeCode = AggregationResolver::STOCK_ATTRIBUTE;
@@ -97,13 +96,11 @@ class StockStatusData implements DatasourceInterface
                 $productData[$attributeCode] = (int)$productData['stock']['is_in_stock'];
 
                 if (
-                    $shouldConsiderOnlyQty &&
-                    (int)$productData['stock']['is_in_stock'] === Stock::STOCK_IN_STOCK &&
+                    $isBackordersAllowed &&
                     isset($productData['stock']['qty'])
                 ) {
                     $qty = (int)$productData['stock']['qty'];
-
-                    $productData[$attributeCode] = ($qty > 0) ? Stock::STOCK_IN_STOCK : Stock::STOCK_OUT_OF_STOCK;
+                    $productData[$attributeCode] = ($qty > .01) ? Stock::STOCK_IN_STOCK : Stock::STOCK_OUT_OF_STOCK;
                 }
             }
         }

--- a/Model/Product/Indexer/Fulltext/Datasource/StockStatusData.php
+++ b/Model/Product/Indexer/Fulltext/Datasource/StockStatusData.php
@@ -95,12 +95,9 @@ class StockStatusData implements DatasourceInterface
             if (isset($productData['stock']) && isset($productData['stock']['is_in_stock'])) {
                 $productData[$attributeCode] = (int)$productData['stock']['is_in_stock'];
 
-                if (
-                    $isBackordersAllowed &&
-                    isset($productData['stock']['qty'])
-                ) {
+                if ($isBackordersAllowed && isset($productData['stock']['qty'])) {
                     $qty = (int)$productData['stock']['qty'];
-                    $productData[$attributeCode] = ($qty > .01) ? Stock::STOCK_IN_STOCK : Stock::STOCK_OUT_OF_STOCK;
+                    $productData[$attributeCode] = ($qty > 0.01) ? Stock::STOCK_IN_STOCK : Stock::STOCK_OUT_OF_STOCK;
                 }
             }
         }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -21,11 +21,6 @@
                     <label>Display Out Of Stock Filter</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <field id="consider_only_qty" translate="label comment" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
-                    <label>Consider Only Product Quantity</label>
-                    <comment>If set to Yes, stock filter will consider only product quantity. Products with qty ≤ 0 will be considered out of stock. Please note, if you change this value, you will need to reindex Catalog Search index</comment>
-                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                </field>
             </group>
         </section>
     </system>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -14,7 +14,6 @@
         <amadeco_elasticsuite_stock>
             <general>
                 <display_out_of_stock_filter>0</display_out_of_stock_filter>
-                <consider_only_qty>1</consider_only_qty>
             </general>
         </amadeco_elasticsuite_stock>
     </default>


### PR DESCRIPTION
- Respect native logic for is_in_stock status even if _Backorders_ is enabled.
- Check quantity on decimal level if option _Qty Uses Decimals_ is enabled.