### PR TITLE
Refactor stock filter to TypeProvider pattern; drop Smile_ElasticsuiteRating dependency

### DIFF
--- a/Model/Layer/Filter/TypeProvider/Stock.php
+++ b/Model/Layer/Filter/TypeProvider/Stock.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Amadeco ElasticsuiteStock Module
+ *
+ * @category   Amadeco
+ * @package    Amadeco_ElasticsuiteStock
+ * @author     Ilan Parmentier
+ */
+declare(strict_types=1);
+
+namespace Amadeco\ElasticsuiteStock\Model\Layer\Filter\TypeProvider;
+
+use Amadeco\ElasticsuiteStock\Model\Layer\Filter\Stock as StockFilter;
+use Amadeco\ElasticsuiteStock\Plugin\Search\Request\Product\Attribute\AggregationResolver;
+use Magento\Catalog\Model\ResourceModel\Eav\Attribute;
+use Smile\ElasticsuiteCatalog\Api\Layer\Filter\TypeProviderInterface;
+
+/**
+ * Filter type provider for the Stock layer filter.
+ *
+ * Registers the custom Stock renderer for the stock status attribute through the
+ * core Smile\ElasticsuiteCatalog\Model\Layer\FilterList filterTypeProviders pool,
+ * so no FilterList override (preference / virtualType) is required.
+ */
+class Stock implements TypeProviderInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function getFilterClassName(Attribute $attribute, string $originalFilterClassName): string
+    {
+        if ($attribute->getAttributeCode() === AggregationResolver::STOCK_ATTRIBUTE) {
+            return StockFilter::class;
+        }
+
+        return $originalFilterClassName;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -96,27 +96,36 @@ Instead of relying on Magento's `quantity_and_stock_status` attribute (which has
 
 ## Compatibility with Other ElasticSuite Modules
 
-### Dependency on Smile_ElasticsuiteRating: Technical Explanation
+### Filter registration: TypeProvider pattern (no FilterList override)
 
-Smile_ElasticsuiteRating is a required dependency due to how Magento's preference system works:
+This module has **no dependency** on `Smile_ElasticsuiteRating` and does **not** override
+`Smile\ElasticsuiteCatalog\Model\Layer\FilterList`.
 
-Both modules (Rating and our Stock module) attempt to override Smile\ElasticsuiteCatalog\Model\Layer\FilterList using preferences.
-In Magento's preference system, when multiple modules declare a preference for the same class, only the last one loaded (based on module loading order) takes effect.
-If Smile_ElasticsuiteRating is installed but our module's preference isn't properly applied, our stock filter won't appear in the layered navigation.
-
-To solve this conflict, we must:
+The stock renderer is registered through the core ElasticSuite `filterTypeProviders` pool.
+`Smile\ElasticsuiteCatalog\Model\Layer\FilterList::getAttributeFilterClass()` iterates every
+injected `Smile\ElasticsuiteCatalog\Api\Layer\Filter\TypeProviderInterface` and lets it swap
+the filter class for its attribute. We provide one for `stock_status`:
 
 ```xml
-<preference for="Smile\ElasticsuiteCatalog\Model\Layer\FilterList" 
-            type="Amadeco\ElasticsuiteStock\Model\Layer\FilterList"/>
-            
-<preference for="Smile\ElasticsuiteRating\Model\Layer\FilterList" 
-            type="Amadeco\ElasticsuiteStock\Model\Layer\FilterList"/>
+<type name="Smile\ElasticsuiteCatalog\Model\Layer\FilterList">
+    <arguments>
+        <argument name="filterTypeProviders" xsi:type="array">
+            <item name="stock" xsi:type="object">Amadeco\ElasticsuiteStock\Model\Layer\Filter\TypeProvider\Stock</item>
+        </argument>
+    </arguments>
+</type>
 ```
 
-This approach requires Smile_ElasticsuiteRating to be present since we're explicitly overriding its class. Without it, Magento would throw a fatal error when trying to resolve this preference.
+Because the core `categoryFilterList` and `searchFilterList` virtual types extend that base
+type, they inherit the provider automatically — no preference, no virtual-type override, and
+no module load-order constraint against other filter modules.
 
-**Note:** We recognize that the current dependency on Smile_ElasticsuiteRating is not ideal. In a future release, we plan to implement a more flexible architecture.
+Earlier versions extended `FilterList` and added a second preference over
+`Smile\ElasticsuiteRating\Model\Layer\FilterList` to resolve a preference conflict. Both the
+rating module ([PR #19](https://github.com/Smile-SA/magento2-module-elasticsuite-rating/pull/19))
+and this module have since migrated to the `TypeProvider` pattern, so the conflict — and the
+dependency — no longer exist. Multiple filter modules now coexist cleanly because each only
+appends its own provider to the shared pool.
 
 ## License
 

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,7 @@
         "inventory"
     ],
     "require": {
-        "smile/elasticsuite": ">=2.8.0",
-        "smile/module-elasticsuite-rating": "^2.3"
+        "smile/elasticsuite": ">=2.8.0"
     },
     "autoload": {
         "files": [

--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -11,25 +11,12 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
 
-    <!-- Base preference for Smile ElasticsuiteCatalog's FilterList -->
-    <preference for="Smile\ElasticsuiteCatalog\Model\Layer\FilterList" type="Amadeco\ElasticsuiteStock\Model\Layer\FilterList"/>
-
-    <!-- Virtual types for category and search filter lists -->
-    <virtualType name="categoryFilterList" type="Amadeco\ElasticsuiteStock\Model\Layer\FilterList">
+    <!-- Register the stock filter type provider on the core ElasticSuite FilterList. -->
+    <type name="Smile\ElasticsuiteCatalog\Model\Layer\FilterList">
         <arguments>
-            <argument name="filters" xsi:type="array">
-                <item name="stock" xsi:type="string">Amadeco\ElasticsuiteStock\Model\Layer\Filter\Stock</item>
+            <argument name="filterTypeProviders" xsi:type="array">
+                <item name="stock" xsi:type="object">Amadeco\ElasticsuiteStock\Model\Layer\Filter\TypeProvider\Stock</item>
             </argument>
         </arguments>
-    </virtualType>
-    <virtualType name="searchFilterList" type="Amadeco\ElasticsuiteStock\Model\Layer\FilterList">
-        <arguments>
-            <argument name="filters" xsi:type="array">
-                <item name="stock" xsi:type="string">Amadeco\ElasticsuiteStock\Model\Layer\Filter\Stock</item>
-            </argument>
-        </arguments>
-    </virtualType>
-
-    <!-- preference to overwritte virtual type of Smile_ElasticsuiteRating -->
-    <preference for="Smile\ElasticsuiteRating\Model\Layer\FilterList" type="Amadeco\ElasticsuiteStock\Model\Layer\FilterList"/>
+    </type>
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -11,7 +11,6 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
     <module name="Amadeco_ElasticsuiteStock">
         <sequence>
-            <module name="Smile_ElasticsuiteRating" />
             <module name="Smile_ElasticsuiteCatalog" />
         </sequence>
     </module>


### PR DESCRIPTION
## Summary

  Migrates the layered-navigation stock filter registration from the legacy
  `FilterList` override to ElasticSuite's `TypeProviderInterface` pool, and removes
  the now-obsolete hard dependency on `Smile_ElasticsuiteRating`.

  ElasticSuite refactored `Smile\ElasticsuiteCatalog\Model\Layer\FilterList::getAttributeFilterClass()`
  to iterate an injected `filterTypeProviders` array, letting each
  `Smile\ElasticsuiteCatalog\Api\Layer\Filter\TypeProviderInterface` swap the filter
  class for its own attribute. `Smile_ElasticsuiteRating` adopted this in
  [Smile-SA/magento2-module-elasticsuite-rating#19](https://github.com/Smile-SA/magento2-module-elasticsuite-rati
  ng/pull/19),
  dropping its own `Model/Layer/FilterList` subclass. This module now does the same.

  ## Background

  Previously both this module and `Smile_ElasticsuiteRating` extended
  `Smile\ElasticsuiteCatalog\Model\Layer\FilterList` via a `<preference>`. Because
  Magento applies last-loaded-wins to preferences, the two collided — so this module
  had to `<sequence>` after the rating module, re-declare a `<preference>` over the
  rating `FilterList`, redefine the `categoryFilterList`/`searchFilterList` virtual
  types, and carry a runtime `class_exists()` branch re-implementing rating's filter
  selection. That whole workaround existed only to survive the preference conflict.

  With the provider pool, each module appends its own provider independently — the
  conflict, the override, and the cross-dependency all disappear.

  ## Changes

  - **Add** `Model/Layer/Filter/TypeProvider/Stock.php` implementing
    `TypeProviderInterface`, returning the `Stock` filter for the `stock_status`
    attribute.
  - **Register** the provider on the core type:
```
    <type name="Smile\ElasticsuiteCatalog\Model\Layer\FilterList">
        <arguments>
            <argument name="filterTypeProviders" xsi:type="array">
                <item name="stock"
  xsi:type="object">Amadeco\ElasticsuiteStock\Model\Layer\Filter\TypeProvider\Stock</item>
            </argument>
        </arguments>
    </type>
```
  - Delete Model/Layer/FilterList.php (subclass no longer needed).
  - Remove from `etc/frontend/di.xml`: the `<preference>` over the core
  FilterList, the <preference> over the rating FilterList, and the
  categoryFilterList/searchFilterList virtual-type redefinitions. The core
  virtual types extend the base type, so they inherit the provider automatically.
  - Remove Smile_ElasticsuiteRating from etc/module.xml <sequence>
  (kept Smile_ElasticsuiteCatalog).
  - Remove _smile/module-elasticsuite-rating_ from _composer.json_ require.
  - Update **README.md** to document the _TypeProvider_ pattern.

  Impact / Compatibility

  - No code or composer reference to Smile_ElasticsuiteRating remains; rating is now
  fully optional. When installed it keeps working via its own provider — both
  rating and stock coexist in the shared pool.
  - No module load-order constraint against other filter modules.
  - Requires a recent ElasticSuite Catalog that exposes
  `Smile\ElasticsuiteCatalog\Api\Layer\Filter\TypeProviderInterface` and the
  _filterTypeProviders_ constructor argument on FilterList.

  Verification

  After `bin/magento cache:flush`, both virtual types resolve to the core
  FilterList carrying both providers:

```
  categoryFilterList => Smile\ElasticsuiteCatalog\Model\Layer\FilterList
      provider[rating] = Smile\ElasticsuiteRating\Model\Layer\Filter\TypeProvider\Rating
      provider[stock]  = Amadeco\ElasticsuiteStock\Model\Layer\Filter\TypeProvider\Stock
  searchFilterList   => Smile\ElasticsuiteCatalog\Model\Layer\FilterList  (same providers)

```
  Category and search layered navigation render with the stock filter present.

> Upgrade note: run `bin/magento cache:flush` after deploy — cache:clean config
> does not evict the merged-DI mapping of the filter-list virtual types, and a stale
> entry throws ReflectionException: Class "Amadeco\ElasticsuiteStock\Model\Layer\FilterList" does not exist on category pages until flushed.