### PR TITLE
PHP 8.3 modernization, _initItems performance, and correct ElasticSuite version constraint (2.2.0)

### DIFF
--- a/Api/Data/StockInterface.php
+++ b/Api/Data/StockInterface.php
@@ -22,5 +22,5 @@ interface StockInterface
     /**
      * Indexed stock status attribute code.
      */
-    public const ATTRIBUTE_CODE = 'stock_status';
+    public const string ATTRIBUTE_CODE = 'stock_status';
 }

--- a/Block/Navigation/Renderer/Stock.php
+++ b/Block/Navigation/Renderer/Stock.php
@@ -20,26 +20,20 @@ use Magento\Catalog\Helper\Data as CatalogHelper;
 class Stock extends \Smile\ElasticsuiteCatalog\Block\Navigation\Renderer\Attribute
 {
     /**
-     * @var Json
-     */
-    private Json $serializer;
-
-    /**
      * Constructor
      *
-     * @param Template\Context $context Block context.
-     * @param CatalogHelper $catalogHelper Catalog helper.
-     * @param Json $serializer JSON Serializer
-     * @param array $data Block data
+     * @param Template\Context $context       Block context.
+     * @param CatalogHelper    $catalogHelper Catalog helper.
+     * @param Json             $serializer    JSON Serializer.
+     * @param array            $data          Block data.
      */
     public function __construct(
         Template\Context $context,
         CatalogHelper $catalogHelper,
-        Json $serializer,
+        private readonly Json $serializer,
         array $data = []
     ) {
         parent::__construct($context, $catalogHelper, $data);
-        $this->serializer = $serializer;
     }
 
     /**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to the `Amadeco_ElasticsuiteStock` module are documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] - 2026-06-05
+
+### Changed (Breaking)
+- Minimum PHP raised to **8.3** (`composer.json` now requires `~8.3.0 || ~8.4.0`). The module
+  uses typed class constants (`public const string ATTRIBUTE_CODE`), which are an 8.3-only
+  syntax. Installs on PHP 8.1 / 8.2 must stay on `2.1.x`.
+
+### Fixed
+- Corrected the `smile/elasticsuite` version constraint from `>=2.8.0` to `>=2.12.0`. The
+  filter is registered through the `TypeProviderInterface` / `filterTypeProviders` pool, which
+  ElasticSuite only introduced in **2.12.0**. The old constraint allowed installing 2.8–2.11,
+  where that API does not exist, leading to a fatal error on the storefront. README requirement
+  updated to match.
+
+### Changed
+- Modernized to PHP 8.3 idioms with no behavioral change:
+  - Constructor property promotion across the datasource, aggregation plugin, configuration
+    helper, navigation block, layered-navigation filter and the three setup data patches.
+  - Injected dependencies are now `readonly` (immutable after construction).
+  - Typed class constants on `Api\Data\StockInterface` and `Helper\Config`.
+
+### Performance
+- Removed the `Model\Layer\Filter\Stock::_initItems()` override. It called
+  `parent::_initItems()` and then re-ran the same per-item loop a third time (relabel,
+  apply-value, `krsort`), discarding and recomputing the work the parent had just done. The
+  override only existed to compensate for `_getItemsData()` storing the display text as the
+  item label; that now stores the raw faceted value (0/1) like core ElasticSuite, so the
+  inherited `Smile\…\Boolean::_initItems()` resolves the label via the source model and matches
+  the selection on the value with no extra pass. Net effect: one fewer full item loop and one
+  fewer `krsort` per filter render, plus ~40 lines and three `SuppressWarnings` removed.
+
 ## [2.1.0] - 2026-06-05
 
 ### Added
@@ -22,13 +53,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   hardcoding the "In Stock" / "Out of Stock" strings (DRY: the labels now live in one place).
   The attribute stays hidden from the product form (`input = hidden`, `is_visible = 0`); adding
   a source model only affects label resolution, not form visibility or ElasticSuite filtering.
-
-### Fixed
-- Decimal stock quantities were mis-indexed as out of stock. With backorders enabled, the qty
-  check cast the value to int before comparing (`(int) $qty > 0.01`), so any product with a
-  fractional quantity below 1 (e.g. `0.5` for items sold by weight/length with
-  `is_qty_decimal = 1`) was floored to `0` and indexed as Out of Stock. Now compared as a
-  float (`(float) $qty > 0`).
 
 ## [2.0.0] - 2026-06-05
 
@@ -55,6 +79,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `is_visible = 0` on existing installs (the original create patch does not re-run).
 
 ### Fixed
+- Decimal stock quantities were mis-indexed as out of stock. With backorders enabled, the qty
+  check cast the value to int before comparing (`(int) $qty > 0.01`), so any product with a
+  fractional quantity below 1 (e.g. `0.5` for items sold by weight/length with
+  `is_qty_decimal = 1`) was floored to `0` and indexed as Out of Stock. Now compared as a
+  float (`(float) $qty > 0`).
 - "Display Out Of Stock Filter" admin setting was inverted: enabling it hid the Out-of-Stock
   option instead of showing it. The condition is now correct.
 - `StockSetup` no longer swallows exceptions while creating the attribute; a failed
@@ -70,7 +99,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 - Strict type declarations and return types added across datasource, aggregation and setup.
-- Fractional stock quantity comparison fixed (`(float) $qty > 0` instead of `(int) $qty > 0.01`).
 - PSR-12 / Magento2 coding-standard cleanups: private method renamed off the `_` prefix,
   leading backslashes removed from `di.xml` type name and `use` statements, docblocks aligned.
 - README requirements corrected (the `Smile ElasticSuite Rating` requirement was stale).

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -23,23 +23,18 @@ class Config extends AbstractHelper
     /**
      * Configuration paths
      */
-    public const XML_PATH_DISPLAY_OUT_OF_STOCK = 'amadeco_elasticsuite_stock/general/display_out_of_stock_filter';
+    public const string XML_PATH_DISPLAY_OUT_OF_STOCK
+        = 'amadeco_elasticsuite_stock/general/display_out_of_stock_filter';
 
     /**
-     * @var InventoryConfig
-     */
-    private InventoryConfig $inventoryConfig;
-
-    /**
-     * @param Context $context
-     * @param InventoryConfig $inventoryConfig
+     * @param Context         $context         Helper context.
+     * @param InventoryConfig $inventoryConfig Catalog inventory configuration.
      */
     public function __construct(
         Context $context,
-        InventoryConfig $inventoryConfig
+        private readonly InventoryConfig $inventoryConfig
     ) {
         parent::__construct($context);
-        $this->inventoryConfig = $inventoryConfig;
     }
 
     /**

--- a/Model/Layer/Filter/Stock.php
+++ b/Model/Layer/Filter/Stock.php
@@ -22,7 +22,6 @@ use Smile\ElasticsuiteCatalog\Api\LayeredNavAttributeInterface;
 use Smile\ElasticsuiteCatalog\Helper\ProductAttribute;
 use Smile\ElasticsuiteCatalog\Model\Attribute\LayeredNavAttributesProvider;
 use Smile\ElasticsuiteCatalog\Model\Attribute\Source\FilterDisplayMode;
-use Smile\ElasticsuiteCore\Search\Request\BucketInterface;
 use Amadeco\ElasticsuiteStock\Helper\Config;
 
 /**
@@ -34,11 +33,6 @@ class Stock extends \Smile\ElasticsuiteCatalog\Model\Layer\Filter\Boolean
      * @var StripTags
      */
     private StripTags $tagFilter;
-
-    /**
-     * @var Config
-     */
-    private Config $config;
 
     /**
      * Constructor.
@@ -66,7 +60,7 @@ class Stock extends \Smile\ElasticsuiteCatalog\Model\Layer\Filter\Boolean
         Escaper $escaper,
         ProductAttribute $mappingHelper,
         LayeredNavAttributesProvider $layeredNavAttributesProvider,
-        Config $config,
+        private readonly Config $config,
         array $hideNoValueAttributes = [],
         array $data = []
     ) {
@@ -84,7 +78,6 @@ class Stock extends \Smile\ElasticsuiteCatalog\Model\Layer\Filter\Boolean
         );
 
         $this->tagFilter = $tagFilter;
-        $this->config = $config;
     }
 
     /**
@@ -126,7 +119,14 @@ class Stock extends \Smile\ElasticsuiteCatalog\Model\Layer\Filter\Boolean
     }
 
     /**
-     * Get data array for building filter items
+     * Get data array for building filter items.
+     *
+     * Each item keeps the raw faceted value (0/1) as its label on purpose: the inherited
+     * Smile Boolean::_initItems() then resolves that numeric label to the source-model text
+     * ("In Stock" / "Out of Stock") and matches the active selection on it. Because the stock
+     * values equal Magento's Boolean source values (VALUE_YES = STOCK_IN_STOCK = 1,
+     * VALUE_NO = STOCK_OUT_OF_STOCK = 0), the parent handles labelling, selection and manual
+     * sort with no _initItems() override on this class.
      *
      * @return array
      * @SuppressWarnings(PHPMD.CamelCaseMethodName)
@@ -146,7 +146,7 @@ class Stock extends \Smile\ElasticsuiteCatalog\Model\Layer\Filter\Boolean
         if (!empty($this->currentFilterValue) || $minCount < $productCollection->getSize() || $forceDisplay) {
             foreach ($optionsFacetedData as $value => $data) {
                 $items[$value] = [
-                    'label' => $this->getLabel($value),
+                    'label' => $this->tagFilter->filter((string) $value),
                     'value' => $value,
                     'count' => $data['count'],
                 ];
@@ -158,51 +158,6 @@ class Stock extends \Smile\ElasticsuiteCatalog\Model\Layer\Filter\Boolean
         }
 
         return $items;
-    }
-
-    /**
-     * Initialize filter items, applying selection state and stock-status sort order.
-     *
-     * @return $this
-     *
-     * @SuppressWarnings(PHPMD.CamelCaseMethodName)
-     * @SuppressWarnings(PHPMD.ElseExpression)
-     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
-     */
-    protected function _initItems()
-    {
-        parent::_initItems();
-
-        foreach ($this->_items as $key => $item) {
-            $applyValue = $item->getValue();
-
-            if ($item->getValue() == MagentoModelStock::STOCK_IN_STOCK
-                || $item->getValue() == MagentoModelStock::STOCK_OUT_OF_STOCK
-            ) {
-                if (is_numeric($item->getLabel())) {
-                    $label = $this->getLabel((int) $item->getLabel());
-                    $item->setLabel((string) $label);
-                }
-            }
-
-            if (($valuePos = array_search($applyValue, $this->currentFilterValue)) !== false) {
-                $item->setIsSelected(true);
-                $applyValue = $this->currentFilterValue;
-                unset($applyValue[$valuePos]);
-            } else {
-                $applyValue = array_merge($this->currentFilterValue, [$applyValue]);
-            }
-
-            $item->setApplyFilterValue(array_values($applyValue));
-        }
-
-        if (($this->getAttributeModel()->getFacetSortOrder() == BucketInterface::SORT_ORDER_MANUAL)
-            && (count($this->_items) > 1)
-        ) {
-            krsort($this->_items, SORT_NUMERIC);
-        }
-
-        return $this;
     }
 
     /**

--- a/Model/Product/Indexer/Fulltext/Datasource/StockStatusData.php
+++ b/Model/Product/Indexer/Fulltext/Datasource/StockStatusData.php
@@ -29,19 +29,13 @@ use Smile\ElasticsuiteCore\Api\Index\DatasourceInterface;
 class StockStatusData implements DatasourceInterface
 {
     /**
-     * @var Config
-     */
-    private Config $config;
-
-    /**
      * Constructor.
      *
      * @param Config $config Configuration helper.
      */
     public function __construct(
-        Config $config
+        private readonly Config $config
     ) {
-        $this->config = $config;
     }
 
     /**

--- a/Plugin/Search/Request/Product/Attribute/AggregationResolver.php
+++ b/Plugin/Search/Request/Product/Attribute/AggregationResolver.php
@@ -21,19 +21,13 @@ use Amadeco\ElasticsuiteStock\Search\Request\Product\Attribute\Aggregation\Stock
 class AggregationResolver
 {
     /**
-     * @var StockAggregation
-     */
-    private StockAggregation $stockAggregation;
-
-    /**
      * AggregationResolver constructor.
      *
      * @param StockAggregation $stockAggregation Stock aggregation builder.
      */
     public function __construct(
-        StockAggregation $stockAggregation
+        private readonly StockAggregation $stockAggregation
     ) {
-        $this->stockAggregation = $stockAggregation;
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ bin/magento indexer:reindex catalogsearch_fulltext
 
 - PHP 8.3+
 - Magento 2.4.x
-- Smile ElasticSuite 2.8 or higher
+- Smile ElasticSuite 2.12.0 or higher (introduces the layered-navigation filter `TypeProviderInterface`)
 
 ## Configuration
 

--- a/Setup/Patch/Data/AddStockStatusSource.php
+++ b/Setup/Patch/Data/AddStockStatusSource.php
@@ -28,27 +28,15 @@ use Magento\Framework\Setup\Patch\DataPatchInterface;
 class AddStockStatusSource implements DataPatchInterface
 {
     /**
-     * @var ModuleDataSetupInterface
-     */
-    private ModuleDataSetupInterface $moduleDataSetup;
-
-    /**
-     * @var EavSetupFactory
-     */
-    private EavSetupFactory $eavSetupFactory;
-
-    /**
      * Constructor.
      *
      * @param ModuleDataSetupInterface $moduleDataSetup Module data setup.
      * @param EavSetupFactory          $eavSetupFactory EAV setup factory.
      */
     public function __construct(
-        ModuleDataSetupInterface $moduleDataSetup,
-        EavSetupFactory $eavSetupFactory
+        private readonly ModuleDataSetupInterface $moduleDataSetup,
+        private readonly EavSetupFactory $eavSetupFactory
     ) {
-        $this->moduleDataSetup = $moduleDataSetup;
-        $this->eavSetupFactory = $eavSetupFactory;
     }
 
     /**

--- a/Setup/Patch/Data/CreateStockStatusAttribute.php
+++ b/Setup/Patch/Data/CreateStockStatusAttribute.php
@@ -21,21 +21,6 @@ use Amadeco\ElasticsuiteStock\Setup\StockSetup;
 class CreateStockStatusAttribute implements DataPatchInterface
 {
     /**
-     * @var ModuleDataSetupInterface
-     */
-    private ModuleDataSetupInterface $moduleDataSetup;
-
-    /**
-     * @var EavSetupFactory
-     */
-    private EavSetupFactory $eavSetupFactory;
-
-    /**
-     * @var StockSetup
-     */
-    private StockSetup $stockSetup;
-
-    /**
      * Constructor
      *
      * @param ModuleDataSetupInterface $moduleDataSetup Module data setup.
@@ -43,13 +28,10 @@ class CreateStockStatusAttribute implements DataPatchInterface
      * @param StockSetup               $stockSetup      Stock setup.
      */
     public function __construct(
-        ModuleDataSetupInterface $moduleDataSetup,
-        EavSetupFactory $eavSetupFactory,
-        StockSetup $stockSetup
+        private readonly ModuleDataSetupInterface $moduleDataSetup,
+        private readonly EavSetupFactory $eavSetupFactory,
+        private readonly StockSetup $stockSetup
     ) {
-        $this->moduleDataSetup = $moduleDataSetup;
-        $this->eavSetupFactory = $eavSetupFactory;
-        $this->stockSetup = $stockSetup;
     }
 
     /**

--- a/Setup/Patch/Data/HideStockStatusFromProductForm.php
+++ b/Setup/Patch/Data/HideStockStatusFromProductForm.php
@@ -29,27 +29,15 @@ use Magento\Framework\Setup\Patch\DataPatchInterface;
 class HideStockStatusFromProductForm implements DataPatchInterface
 {
     /**
-     * @var ModuleDataSetupInterface
-     */
-    private ModuleDataSetupInterface $moduleDataSetup;
-
-    /**
-     * @var EavSetupFactory
-     */
-    private EavSetupFactory $eavSetupFactory;
-
-    /**
      * Constructor.
      *
      * @param ModuleDataSetupInterface $moduleDataSetup Module data setup.
      * @param EavSetupFactory          $eavSetupFactory EAV setup factory.
      */
     public function __construct(
-        ModuleDataSetupInterface $moduleDataSetup,
-        EavSetupFactory $eavSetupFactory
+        private readonly ModuleDataSetupInterface $moduleDataSetup,
+        private readonly EavSetupFactory $eavSetupFactory
     ) {
-        $this->moduleDataSetup = $moduleDataSetup;
-        $this->eavSetupFactory = $eavSetupFactory;
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "inventory"
     ],
     "require": {
-        "smile/elasticsuite": ">=2.8.0"
+        "php": "~8.3.0 || ~8.4.0",
+        "smile/elasticsuite": ">=2.12.0"
     },
     "autoload": {
         "files": [


### PR DESCRIPTION
## Overview

  Follow-up to the 2.1 hardening PR. Three things: corrects the `smile/elasticsuite`
  version requirement, removes a redundant pass in the layered-navigation filter,
  and modernizes the module to PHP 8.3 idioms.

  `Magento2` coding standard, 0 errors.

    `filterTypeProviders` pool, which ElasticSuite only introduced in **2.12.0**
    (commit `ad63158d2`, first tagged in 2.12.0; 2.11.x and earlier lack it). The
    old constraint allowed installing 2.8–2.11, where that API does not exist,
    leading to a storefront fatal. README requirement updated to match.

  ## Performance

  - **Removed the `Model\Layer\Filter\Stock::_initItems()` override.** It called
    `parent::_initItems()` (which already runs the full Boolean + Attribute
    apply-value loops and a `krsort`), then re-iterated **every item a third time**
    to recompute apply-values and `krsort` again, discarding the parent's work —
    plus a dead relabel pass.

    It only existed because `_getItemsData()` stored the display text
    (`"In Stock"`) as the item label, which broke the parent's selection match
    (parent matches label vs the value held in `currentFilterValue`).
    `_getItemsData()` now stores the **raw faceted value** (`0/1`) as the label,
    exactly like core ElasticSuite. Since `STOCK_IN_STOCK / STOCK_OUT_OF_STOCK`
    equal `VALUE_YES / VALUE_NO` (`1 / 0`) and the attribute carries the source
    model, the inherited `Boolean::_initItems()` relabels via the source and
    matches selection on the value — identical result, **one fewer full item loop
    and one fewer `krsort` per filter render** (−45 net lines, three
    `SuppressWarnings` removed).

    Verified live on a category of 15,141 products:

    | Request | label | selected | applyVal |
    |---|---|---|---|
    | `?stock_status=1` | `In Stock` | `true` | `[]` (deselect) |
    | no filter | `In Stock` | `false` | `["1"]` (select) |

  ## Changed (Breaking)

  - **Minimum PHP raised to 8.3** (`composer.json` now requires
    `~8.3.0 || ~8.4.0`). The module uses typed class constants
    (`public const string ATTRIBUTE_CODE`), which are 8.3-only syntax. Installs on
    PHP 8.1 / 8.2 must stay on the `2.1.x` line.

  ## Changed

  - Modernized to PHP 8.3 idioms with no behavioral change:
    - Constructor property promotion across the datasource, aggregation plugin,
      configuration helper, navigation block, layered-navigation filter and the
      three setup data patches.
    - Injected dependencies are now `readonly`.
    - Typed class constants on `Api\Data\StockInterface` and `Helper\Config`.

  ## Validation

  - `php -l` clean on all changed files; `composer.json` valid JSON.
  - `phpcs --standard=Magento2` → 0 errors.
  - DI smoke test: every class (including interceptors) resolves — `readonly`
    promotion is DI-safe.
  - Live integration test of the filter on a real category layer (table above).