### PR TITLE
chore: private method getRelNofollowValue calling, Helper\Config -> Model\Config

### DIFF
--- a/Block/Navigation/Renderer/Stock.php
+++ b/Block/Navigation/Renderer/Stock.php
@@ -43,14 +43,21 @@ class Stock extends \Smile\ElasticsuiteCatalog\Block\Navigation\Renderer\Attribu
      */
     public function getJsLayout(): string
     {
-        $filterItems = $this->getFilter()->getItems();
+        $filter = $this->getFilter();
+        $filterItems = $filter->getItems();
+
+        // Inlined on purpose: the parent Smile renderer declares getRelNofollowValue()
+        // as private, so this overridden getJsLayout() cannot delegate to it.
+        $displayRelNofollow = $filter->getAttributeModel()->getIsDisplayRelNofollow()
+            ? self::REL_NOFOLLOW
+            : '';
 
         $jsLayoutConfig = [
             'component'           => self::JS_COMPONENT,
             'maxSize'             => count($filterItems),
             'displayProductCount' => (bool) $this->displayProductCount(),
             'hasMoreItems'        => false,
-            'displayRelNofollow'  => $this->getRelNofollowValue(),
+            'displayRelNofollow'  => $displayRelNofollow,
             'template'            => 'Amadeco_ElasticsuiteStock/stock-filter',
             'items'               => []
         ];

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   updated to match.
 
 ### Changed
+- Moved the configuration helper to a plain model: `Helper\Config` → `Model\Config`. It no
+  longer extends `Magento\Framework\App\Helper\AbstractHelper` (the legacy pattern) and now
+  injects `ScopeConfigInterface` directly instead of pulling in the heavyweight helper
+  `Context`. This also drops the unused `CatalogInventory\Model\Configuration` object
+  dependency — only its `XML_PATH_BACKORDERS` class constant was ever used. The public API
+  (`shouldDisplayOutOfStockFilter()`, `getBackordersMode()`, `isBackordersAllowed()`) is
+  unchanged; the two consumers were updated to the new `use` statement.
 - Modernized to PHP 8.3 idioms with no behavioral change:
   - Constructor property promotion across the datasource, aggregation plugin, configuration
-    helper, navigation block, layered-navigation filter and the three setup data patches.
+    model, navigation block, layered-navigation filter and the three setup data patches.
   - Injected dependencies are now `readonly` (immutable after construction).
-  - Typed class constants on `Api\Data\StockInterface` and `Helper\Config`.
+  - Typed class constants on `Api\Data\StockInterface` and `Model\Config`.
 
 ### Performance
 - Removed the `Model\Layer\Filter\Stock::_initItems()` override. It called

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Amadeco ElasticsuiteStock Module
+ *
+ * @category   Amadeco
+ * @package    Amadeco_ElasticsuiteStock
+ * @author     Ilan Parmentier
+ */
+declare(strict_types=1);
+
+namespace Amadeco\ElasticsuiteStock\Model;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Store\Model\ScopeInterface;
+use Magento\CatalogInventory\Model\Configuration as InventoryConfig;
+use Magento\CatalogInventory\Model\Stock;
+
+/**
+ * ElasticsuiteStock Configuration Model
+ */
+class Config
+{
+    /**
+     * Configuration paths
+     */
+    public const string XML_PATH_DISPLAY_OUT_OF_STOCK
+        = 'amadeco_elasticsuite_stock/general/display_out_of_stock_filter';
+
+    /**
+     * @param ScopeConfigInterface $scopeConfig Application configuration.
+     */
+    public function __construct(
+        private readonly ScopeConfigInterface $scopeConfig
+    ) {
+    }
+
+    /**
+     * Check if we need show out of stock filter
+     *
+     * @param int|null $storeId Store ID
+     *
+     * @return bool
+     */
+    public function shouldDisplayOutOfStockFilter(?int $storeId = null): bool
+    {
+        return $this->scopeConfig->isSetFlag(
+            self::XML_PATH_DISPLAY_OUT_OF_STOCK,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
+    }
+
+    /**
+     * Get backorders mode
+     *
+     * @param int|null $storeId Store ID
+     *
+     * @return int
+     */
+    public function getBackordersMode(?int $storeId = null): int
+    {
+        return (int) $this->scopeConfig->getValue(
+            InventoryConfig::XML_PATH_BACKORDERS,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
+    }
+
+    /**
+     * Check if backorders are allowed
+     *
+     * @param int|null $storeId Store ID
+     *
+     * @return bool
+     */
+    public function isBackordersAllowed(?int $storeId = null): bool
+    {
+        return $this->getBackordersMode($storeId) !== Stock::BACKORDERS_NO;
+    }
+}

--- a/Model/Layer/Filter/Stock.php
+++ b/Model/Layer/Filter/Stock.php
@@ -22,7 +22,7 @@ use Smile\ElasticsuiteCatalog\Api\LayeredNavAttributeInterface;
 use Smile\ElasticsuiteCatalog\Helper\ProductAttribute;
 use Smile\ElasticsuiteCatalog\Model\Attribute\LayeredNavAttributesProvider;
 use Smile\ElasticsuiteCatalog\Model\Attribute\Source\FilterDisplayMode;
-use Amadeco\ElasticsuiteStock\Helper\Config;
+use Amadeco\ElasticsuiteStock\Model\Config;
 
 /**
  * Products Stock Filter Model
@@ -47,7 +47,7 @@ class Stock extends \Smile\ElasticsuiteCatalog\Model\Layer\Filter\Boolean
      * @param Escaper                      $escaper                      Html Escaper.
      * @param ProductAttribute             $mappingHelper                Mapping helper.
      * @param LayeredNavAttributesProvider $layeredNavAttributesProvider Layered navigation attributes Provider.
-     * @param Config                       $config                       Stock configuration helper.
+     * @param Config                       $config                       Stock configuration model.
      * @param array                        $hideNoValueAttributes        Attributes hiding the no-value option.
      * @param array                        $data                         Custom data.
      */

--- a/Model/Product/Indexer/Fulltext/Datasource/StockStatusData.php
+++ b/Model/Product/Indexer/Fulltext/Datasource/StockStatusData.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 namespace Amadeco\ElasticsuiteStock\Model\Product\Indexer\Fulltext\Datasource;
 
 use Amadeco\ElasticsuiteStock\Api\Data\StockInterface;
-use Amadeco\ElasticsuiteStock\Helper\Config;
+use Amadeco\ElasticsuiteStock\Model\Config;
 use Magento\CatalogInventory\Model\Stock;
 use Smile\ElasticsuiteCore\Api\Index\DatasourceInterface;
 
@@ -31,7 +31,7 @@ class StockStatusData implements DatasourceInterface
     /**
      * Constructor.
      *
-     * @param Config $config Configuration helper.
+     * @param Config $config Configuration model.
      */
     public function __construct(
         private readonly Config $config


### PR DESCRIPTION
### Fixed
- Storefront fatal when the stock filter rendered in layered navigation: `Block\Navigation\Renderer\Stock::getJsLayout()` called `$this->getRelNofollowValue()`, but that method is declared `private` on the parent `Smile\ElasticsuiteCatalog\Block\Navigation\Renderer\Attribute`, so it is not visible from the child — every render of the `stock_status` facet raised `Error: Call to private method ...getRelNofollowValue() from scope Amadeco\...\Stock` (a 500 on any mixed-stock category/search page where the facet is shown). The rel-nofollow value is now computed inline from the attribute model (`getIsDisplayRelNofollow()`) and the inherited `self::REL_NOFOLLOW` constant, with no dependency on the private parent method. Behavior is unchanged.

### Changed
- Moved the configuration helper to a plain model: `Helper\Config` → `Model\Config`. It no
  longer extends `Magento\Framework\App\Helper\AbstractHelper` (the legacy pattern) and now
  injects `ScopeConfigInterface` directly instead of pulling in the heavyweight helper
  `Context`. This also drops the unused `CatalogInventory\Model\Configuration` object
  dependency — only its `XML_PATH_BACKORDERS` class constant was ever used. The public API
  (`shouldDisplayOutOfStockFilter()`, `getBackordersMode()`, `isBackordersAllowed()`) is
  unchanged; the two consumers were updated to the new `use` statement.